### PR TITLE
Updated command for installing theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ nightfly.yazi is based on [nightfly](https://github.com/bluz71/vim-nightfly-guic
 ## 🎨 Installation
 
 ```bash
-ya pack -a tkapias/nightfly.yazi
+ya pack -a tkapias/nightfly
 ```
 
 ## ⚙️ Usage


### PR DESCRIPTION
The previous command did not install the theme correctly. It gave me this error:

```
$ ya pack -a tkapias/nightfly.yazi                                                                                                              [22:30:17]

  Upgrading package `nightfly.yazi.yazi`

Cloning into '/my/yazi/packages/directory'...
remote: Repository not found.
fatal: repository 'https://github.com/tkapias/nightfly.yazi.yazi.git/' not found
Error: `git` command failed: exit status: 128
```

Here are the logs with this change:

```
$ ya pack -a tkapias/nightfly                                                                                                                   [22:30:55]

  Upgrading package `nightfly.yazi`

Cloning into '/my/yazi/packages/directory'...
remote: Enumerating objects: 10, done.
remote: Counting objects: 100% (10/10), done.
remote: Compressing objects: 100% (9/9), done.
remote: Total 10 (delta 1), reused 7 (delta 0), pack-reused 0 (from 0)
Receiving objects: 100% (10/10), 675.35 KiB | 4.93 MiB/s, done.
Resolving deltas: 100% (1/1), done.

  Deploying package `nightfly.yazi`

Done!
```